### PR TITLE
79 split offer request

### DIFF
--- a/lib/flying_penguin_web/live/search_live/new.ex
+++ b/lib/flying_penguin_web/live/search_live/new.ex
@@ -41,8 +41,7 @@ defmodule FlyingPenguinWeb.SearchLive.New do
   end
 
   def handle_event("search", %{"search" => search_params}, socket) do
-    IO.inspect search_params
-    {:ok, %{data: response}} = Client.get_offers(search_params)
+    response = Client.get_offers(search_params)
 
     # insert method to parse response for display
     {:noreply, assign(socket, response: Client.parse_response(response))}


### PR DESCRIPTION
Previously we were submitting the post request and defining return_offers=true. This resulted in the request sending back all of the offers that matched the request body params. 

The better way to handle this is to use two requests, one to create a offer request, and the other to list offers 

POST `?request_offers=false`
GET `?request_id=<id>&sort=total_amount&limit=<number_of_offers>`

This allows for sorting and pagination on Duffel's servers rather than having to bring that into our code base. We might see some latency improvements as well.

closes #79 